### PR TITLE
updating README git URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Docverter is a document conversion server with an HTTP interface. It wrap the fo
 
 Installing on Heroku is the easiest option. Simply clone the repo, create an app, and push:
 
-    $ git clone https://github.com/docverter/docverter.git
+    $ git clone https://github.com/Docverter/docverter.git
     $ cd docverter
-    $ heroku create --buildpack https://github.com/ddollar/heroku-buildpack-multi
+    $ heroku create --buildpack https://github.com/ddollar/heroku-buildpack-multi.git
     $ heroku config:add PATH=bin:/app/bin:/app/jruby/bin:/usr/bin:/bin
     $ git push heroku master
     


### PR DESCRIPTION
the 'git clone' fails for me w/ case-insensitive docverter/docverter, and heroku's anvil build server (https://github.com/ddollar/anvil) expects buildpack URLs to be repositories and end in .git, so I updated that too
