### PR TITLE
Possible fix for "fatal: Not a git repository (or any of the parent directories): .git"

### DIFF
--- a/docverter.gemspec
+++ b/docverter.gemspec
@@ -12,9 +12,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'http://www.docverter.com'
   gem.platform      = "java"
 
-  gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
   gem.add_dependency('mime-types')


### PR DESCRIPTION
Hi,

> git push heroku master
> Counting objects: 166, done.
> Delta compression using up to 4 threads.
> Compressing objects: 100% (85/85), done.
> Writing objects: 100% (166/166), 1.66 MiB | 50 KiB/s, done.
> Total 166 (delta 67), reused 166 (delta 67)
> 
> -----> Fetching custom git buildpack... done
> -----> Multipack app detected
> =====> Downloading Buildpack: https://github.com/peterkeen/heroku-buildpack-vendorbinaries.git
> =====> Detected Framework: VendorBinaries
> -----> Found a .vendor_urls file
>        Vendoring https://s3.amazonaws.com/docverter-binaries/calibre.tar.gz
>        Vendoring https://s3.amazonaws.com/docverter-binaries/pandoc.tar.gz
>        Vendoring https://s3.amazonaws.com/docverter-binaries/pandoc-templates.tar.gz
> =====> Downloading Buildpack: https://github.com/jruby/heroku-buildpack-jruby.git
> =====> Detected Framework: JRuby
> -----> Downloading and unpacking JRuby
> -----> Installing JRuby-OpenSSL, Bundler and Rake
>        Successfully installed bouncy-castle-java-1.5.0147
>        Successfully installed jruby-openssl-0.8.8
>        Successfully installed bundler-1.3.5
>        Successfully installed rake-10.0.4
>        4 gems installed
> -----> Vendoring JRuby into slug
> -----> Installing dependencies with Bundler
> fatal: Not a git repository (or any of the parent directories): .git
>        Fetching gem metadata from http://rubygems.org/.........
>        Fetching gem metadata from http://rubygems.org/..
>        Installing rake (10.0.2)
>        Installing ffi (1.2.0)
>        Installing childprocess (0.3.6)
>        Installing choice (0.1.6)
>        Installing flying_saucer (0.8.0)
>        Installing mime-types (1.19)
>        Installing rack (1.4.1)
>        Installing mizuno (0.6.4)
>        Installing rack-protection (1.2.0)
>        Installing tilt (1.3.3)
>        Installing sinatra (1.3.3)
>        Using docverter-server (1.0.1) from source at .
>        Using bundler (1.3.5)
>        Your bundle is complete!
>        Gems in the groups development and test were not installed.
>        It was installed into ./vendor/bundle
>        Dependencies installed
> -----> Writing config/database.yml to read from DATABASE_URL
>        Using release configuration from last framework JRuby:
>        ---
>        addons:
>        config_vars:
>          PATH: bin:jruby/bin:/usr/bin:/bin
>          RACK_ENV: production
>          RAILS_ENV: production
>          JRUBY_OPTS: -J-Xmx400m
>        default_process_types:
> -----> Discovering process types
>        Procfile declares types -> web
> 
> -----> Compiled slug size: 100.8MB
> -----> Launching... done, v5
>        http://docserver-test.herokuapp.com deployed to Heroku
> 
> To git@heroku.personal:docserver-test.git
> - [new branch]      master -> master

Found a similar issue here https://github.com/heroku/heroku-buildpack-ruby/issues/3 and the solution https://gist.github.com/hone/12a88ee5853cff734502. Worked for me.

Cheers!

Pradeepto
