### PR TITLE
Retry opening output_file if it fails

### DIFF
--- a/lib/docverter-server/app.rb
+++ b/lib/docverter-server/app.rb
@@ -40,10 +40,23 @@ class DocverterServer::App < Sinatra::Base
 
       content_type(DocverterServer::ConversionTypes.mime_type(manifest['to']))
 
+      num_tries = 0
+      max_retries = 10
       @output = nil
-      File.open(output_file) do |f|
-        @output = f.read
+
+      while num_tries < max_retries
+        begin
+          File.open(output_file) do |f|
+            @output = f.read
+          end
+          num_tries += 1
+          break
+        rescue
+          puts "Failed to open #{output_file}; num_tries = #{num_tries}"
+          sleep 0.020
+        end
       end
+
       @output
     end
 


### PR DESCRIPTION
Hoping that this fixes intermittent 500 errors due to inability to open temp files, as seen in #28.

Or maybe at least gives us more info about whether this is the problem.

I tested this by adding a bit of code to simulate a temporary problem opening a file:

```ruby
      while num_tries < max_retries
        begin
          File.open(output_file) do |f|
            @output = f.read
          end
          num_tries += 1
          if num_tries < 3 then
            File.open("some_file_that_doesnt_exist.txt") do |f|
              @output = f.read
            end
          end
          break
        rescue
          puts "Failed to open #{output_file}; num_tries = #{num_tries}"
          sleep 0.020
        end
      end
```

Result of running this and hitting it with HTTPie:

```
$ foreman start
file:/Users/marca/.rvm/rubies/jruby-1.7.4/lib/jruby.jar!/jruby/kernel19/process.rb:4 warning: unsupported spawn option: err
file:/Users/marca/.rvm/rubies/jruby-1.7.4/lib/jruby.jar!/jruby/kernel19/process.rb:4 warning: unsupported spawn option: out
15:02:10 web.1  | started with pid 68484
Mizuno 0.6.6 (Jetty 8.1.3.v20120416) listening on 0.0.0.0:5000
["pandoc", "--standalone", "--output=output.a6f8e0c2b17d45e2999d.rst", "--from=markdown", "--to=rst", "tmpqBtaRr"]
"pandoc --standalone --output\\=output.a6f8e0c2b17d45e2999d.rst --from\\=markdown --to\\=rst tmpqBtaRr 2>&1"
Failed to open output.a6f8e0c2b17d45e2999d.rst; num_tries = 1
Failed to open output.a6f8e0c2b17d45e2999d.rst; num_tries = 2
127.0.0.1 - - [02/Feb/2015 15:07:05] "POST /convert HTTP/1.1" 200 - 0.3130
```

```
$ http --form -f POST http://localhost:5000/convert from=markdown to=rst 'input_files[]@/tmp/tmpqBtaRr'
HTTP/1.1 200 OK
Content-Length: 61
Content-Type: application/octet-stream
X-Content-Type-Options: nosniff

pydocverter
===========

Python client for Docverter service
```

So it failed to open the file twice and then it succeeded on the 3rd try and everything works.