### PR TITLE
Suppress rvm warning about ruby not installed.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
 
+#ruby=jruby-1.7.4
 ruby '1.9.3', engine: 'jruby', engine_version: '1.7.4'
 
 gemspec


### PR DESCRIPTION
RVM gets confused by jruby because of the `engine` and `engine_version` in the `Gemfile`, resulting in warnings like:

```
[marca@marca-mac2 ~RVM_PROJECT_PATH]$ pushd /tmp
[marca@marca-mac2 /tmp]$ popd
ruby-1.9.3,:engine=>jruby,:engine_version=>1.7.4 is not installed.
To install do: 'rvm install ruby-1.9.3,:engine=>jruby,:engine_version=>1.7.4'
```

This adds a comment that tells rvm to use jruby so it doesn't get confused.

See: https://github.com/wayneeseguin/rvm/issues/2191