### PR TITLE
Move `require 'securerandom'` to where it's used

### DIFF
--- a/lib/docverter-server/runner/base.rb
+++ b/lib/docverter-server/runner/base.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'securerandom'
 require 'shellwords'
 
 module DocverterServer

--- a/lib/docverter-server/runner/pandoc.rb
+++ b/lib/docverter-server/runner/pandoc.rb
@@ -1,11 +1,9 @@
-require 'securerandom'
-
 class DocverterServer::Runner::Pandoc < DocverterServer::Runner::Base
 
   def run
     with_manifest do |manifest|
       options = manifest.command_options
-      
+
       extension = DocverterServer::ConversionTypes.extension(manifest['to'])
       output = generate_output_filename(extension)
 


### PR DESCRIPTION
Move it from `lib/docverter-server/runner/pandoc.rb` to `lib/docverter-server/runner/base.rb`