### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------
+# This is a Dockerfile to build a Docverter Docker image
+#
+# Build a Docker image with a command like:
+#
+#     docker build -t docverter .
+#
+# And then run a container from that image with a command like:
+#
+#     docker run -it -p 5000:5000 docverter
+# --------------------------------------------------------------------------
+
+FROM jruby:1.7-onbuild
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C
+
+RUN apt-get update && apt-get install -y \
+    pandoc \
+    pandoc-citeproc \
+    pandoc-data \
+    calibre \
+    calibre-bin
+EXPOSE 5000
+CMD ["foreman", "start"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'http://rubygems.org'
 
-ruby '1.9.3', engine: 'jruby', engine_version: '1.7.4'
+ruby '1.9.3', engine: 'jruby', engine_version: '1.7.19'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'http://rubygems.org'
-
 ruby '1.9.3', engine: 'jruby', engine_version: '1.7.19'
-
 gemspec
+
+gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,8 +18,12 @@ GEM
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.1.6)
+    dotenv (1.0.2)
     ffi (1.9.0-java)
     flying_saucer (0.8.0-java)
+    foreman (0.77.0)
+      dotenv (~> 1.0.2)
+      thor (~> 0.19.1)
     i18n (0.6.1)
     metaclass (0.0.1)
     mime-types (1.25)
@@ -45,6 +49,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    thor (0.19.1)
     tilt (1.4.1)
 
 PLATFORMS
@@ -52,5 +57,6 @@ PLATFORMS
 
 DEPENDENCIES
   docverter-server!
+  foreman
   mocha
   shoulda

--- a/docverter.gemspec
+++ b/docverter.gemspec
@@ -1,10 +1,9 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'docverter-server/version'
 
 Gem::Specification.new do |gem|
   gem.name          = "docverter-server"
-  gem.version       = DocverterServer::VERSION
+  gem.version       = "1.0.3"
   gem.authors       = ["Pete Keen"]
   gem.email         = ["pete@docverter.com"]
   gem.description   = %{Document conversion service with a REST API}


### PR DESCRIPTION
This adds a `Dockerfile` to build a Docverter Docker image.

Build a Docker image with a command like:

    docker build -t docverter .

And then run a container from that image with a command like:

    docker run -it -p 5000:5000 docverter

I've already built an image of my own and uploaded it to the Docker hub, so you can simply do the following to run Docverter in a Docker container:

    docker run -it -p 5000:5000 msabramo/docverter
