### PR TITLE
use heroku's built-in multi buildpack support

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/peterkeen/heroku-buildpack-vendorbinaries.git
-https://github.com/heroku/heroku-buildpack-ruby.git

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Installing on Heroku is the easiest option. Simply clone the repo, create an app
 
     $ git clone https://github.com/Docverter/docverter.git
     $ cd docverter
-    $ heroku create --buildpack https://github.com/ddollar/heroku-buildpack-multi.git
+    $ heroku create
+    $ heroku buildpacks:add heroku/ruby
+    $ heroku buildpacks:add https://github.com/peterkeen/heroku-buildpack-vendorbinaries
     $ heroku config:add PATH=bin:/app/bin:/app/jruby/bin:/usr/bin:/bin:/app/calibre/bin
     $ heroku config:add LD_LIBRARY_PATH=/app/calibre/lib
     $ git push heroku master


### PR DESCRIPTION
@ddollar's [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi.git) was [deprecated](https://github.com/ddollar/heroku-buildpack-multi/commit/fe820b194274a5e092e4bccec961d990efb20195) this year and will [auto-destruct in 2017](https://github.com/ddollar/heroku-buildpack-multi/blob/master/bin/compile#L8-L15) 💣

This PR uses Heroku's built-in [Multiple Buildpack](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack) feature and adds @peterkeen's `vendorbinaries` buildpack directly.
