### PR TITLE
remove custom pandoc templates

### DIFF
--- a/.vendor_urls
+++ b/.vendor_urls
@@ -1,3 +1,2 @@
 https://s3.amazonaws.com/docverter-binaries/calibre.tar.gz
 https://s3-eu-west-1.amazonaws.com/hubbado-heroku-binaries/pandoc-1.15.0.6.tar.gz
-https://s3.amazonaws.com/docverter-binaries/pandoc-templates-1.12.0.2.tar.gz


### PR DESCRIPTION
The custom templates included have a bug where documents converted to `.docx` fail to highlight links. I found that deleting these and relying on Pandoc's defaults fixed the problem.

I understand that there may be other reasons to have custom templates, and maybe they only need updating, but I don't what cases these templates are supposed to cover.

Feel free to close this PR if you think it's too drastic, but please let me know what I can do to fix this bug. 😸 
